### PR TITLE
Allow to pass "description" prop to GraphQLStringFactory

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var Kind = require('graphql/language').Kind;
 var GraphQLStringFactory = function(attrs) {
   return new GraphQLScalarType({
     name: attrs.name,
+    description: attrs.description,
     serialize: function(value) {
       return value;
     },


### PR DESCRIPTION
Like so:

```
gtf.GraphQLStringFactory({
    name: 'something',
    description: 'Something',
    fn(ast) {
      return ~args.indexOf(ast.value)
    }
  })
```
